### PR TITLE
Weak inequality in quota rule

### DIFF
--- a/apportionment.py
+++ b/apportionment.py
@@ -163,7 +163,7 @@ def quota(distribution, seats, parties=string.ascii_uppercase, verbose=True):
         quotas = [mpq(distribution[i],representatives[i]+1) for i in range(len(distribution))]
         # check if upper quota is violated
         for i in range(len(distribution)):
-            if representatives[i] > math.ceil(float(distribution[i])*k/sum(distribution)):  
+            if representatives[i] >= math.ceil(float(distribution[i])*k/sum(distribution)):  
                 quotas[i] = 0
         chosen = [i for i in range(len(distribution)) if quotas[i] == max(quotas)]
         if verbose:


### PR DESCRIPTION
Eligibility for the quota rule is defined using a strict inequality (see second paragraph of Section 5, p.714 of the paper), so that ineligibility should use a weak inequality. Without this change, for example, quota((0.625, 0.125, 0.125, 0.125),4) gives all 4 seats to the first party, violating its upper quota.